### PR TITLE
nrf: Use SoftDevice API for flash access when built for SD

### DIFF
--- a/ports/nrf/Makefile
+++ b/ports/nrf/Makefile
@@ -159,6 +159,7 @@ SRC_C += \
 	gccollect.c \
 	pin_named_pins.c \
 	fatfs_port.c \
+	drivers/flash.c \
 	drivers/softpwm.c \
 	drivers/ticker.c \
 	drivers/bluetooth/ble_drv.c \

--- a/ports/nrf/drivers/bluetooth/ble_drv.c
+++ b/ports/nrf/drivers/bluetooth/ble_drv.c
@@ -37,7 +37,7 @@
 #include "ble_gap.h"
 #include "ble.h" // sd_ble_uuid_encode
 #include "hal_irq.h"
-#include "hal/hal_nvmc.h"
+#include "drivers/flash.h"
 #include "mphalport.h"
 
 
@@ -906,12 +906,12 @@ void ble_drv_discover_descriptors(void) {
 
 static void sd_evt_handler(uint32_t evt_id) {
     switch (evt_id) {
-#ifdef HAL_NVMC_MODULE_ENABLED
+#if MICROPY_HW_HAS_BUILTIN_FLASH
         case NRF_EVT_FLASH_OPERATION_SUCCESS:
-            hal_nvmc_operation_finished(HAL_NVMC_SUCCESS);
+            flash_operation_finished(FLASH_STATE_SUCCESS);
             break;
         case NRF_EVT_FLASH_OPERATION_ERROR:
-            hal_nvmc_operation_finished(HAL_NVMC_ERROR);
+            flash_operation_finished(FLASH_STATE_ERROR);
             break;
 #endif
         default:

--- a/ports/nrf/drivers/flash.c
+++ b/ports/nrf/drivers/flash.c
@@ -1,0 +1,132 @@
+/*
+ * This file is part of the Micro Python project, http://micropython.org/
+ *
+ * The MIT License (MIT)
+ *
+ * Copyright (c) 2018 Ayke van Laethem
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+
+#include "py/mpconfig.h"
+
+#if MICROPY_HW_HAS_BUILTIN_FLASH && BLUETOOTH_SD
+
+#include "drivers/flash.h"
+#include "drivers/bluetooth/ble_drv.h"
+#include "nrf_soc.h"
+
+// Rotates bits in `value` left `shift` times.
+STATIC inline uint32_t rotate_left(uint32_t value, uint32_t shift) {
+    return (value << shift) | (value >> (32 - shift));
+}
+
+STATIC volatile flash_state_t flash_operation_state = FLASH_STATE_BUSY;
+
+STATIC void operation_init() {
+    flash_operation_state = FLASH_STATE_BUSY;
+}
+
+void flash_operation_finished(flash_state_t result) {
+    flash_operation_state = result;
+}
+
+STATIC bool operation_wait(uint32_t result) {
+    if (ble_drv_stack_enabled() != 1) {
+        // SoftDevice is not enabled, no event will be generated.
+        return result == NRF_SUCCESS;
+    }
+
+    if (result != NRF_SUCCESS) {
+        // In all other (non-success) cases, the command hasn't been
+        // started and no event will be generated.
+        return false;
+    }
+
+    // Wait until the event has been generated.
+    while (flash_operation_state == FLASH_STATE_BUSY) {
+        sd_app_evt_wait();
+    }
+
+    // Now we can safely continue, flash operation has completed.
+    return flash_operation_state == FLASH_STATE_SUCCESS;
+}
+
+void flash_write_byte(uint32_t address, uint8_t b) {
+    uint32_t address_aligned = address & ~3;
+
+    // Value to write - leave all bits that should not change at 0xff.
+    uint32_t value = 0xffffff00 | b;
+
+    // Rotate bits in value to an aligned position.
+    value = rotate_left(value, (address & 3) * 8);
+
+    while (1) {
+        operation_init();
+        uint32_t result = sd_flash_write((uint32_t*)address_aligned, &value, 1);
+        if (operation_wait(result)) break;
+    }
+}
+
+void flash_page_erase(uint32_t pageaddr) {
+    while (1) {
+        operation_init();
+        uint32_t result = sd_flash_page_erase(pageaddr / FLASH_PAGESIZE);
+        if (operation_wait(result)) break;
+    }
+}
+
+void flash_write_bytes(uint32_t dst, const uint8_t *src, uint32_t num_bytes) {
+    const uint8_t *src_end = src + num_bytes;
+
+    // sd_flash_write does not accept unaligned addresses so we have to
+    // work around that by writing all unaligned addresses byte-by-byte.
+
+    // Write first bytes to align the write address.
+    while (src != src_end && (dst & 0b11)) {
+        flash_write_byte(dst, *src);
+        dst++;
+        src++;
+    }
+
+    // Write as many words as possible.
+    // dst is now aligned, src possibly not.
+    while (src_end - src >= 4) {
+        uint8_t buf[4] __attribute__((aligned(4)));
+        for (int i = 0; i < 4; i++) {
+            buf[i] = ((uint8_t*)src)[i];
+        }
+        operation_init();
+        uint32_t result = sd_flash_write((uint32_t*)dst, (const uint32_t*)&buf, 1);
+        if (operation_wait(result)) {
+            // If it is successfully written, go to the next word.
+            src += 4;
+            dst += 4;
+        }
+    }
+
+    // Write remaining unaligned bytes.
+    while (src != src_end) {
+        flash_write_byte(dst, *src);
+        dst++;
+        src++;
+    }
+}
+
+#endif // MICROPY_HW_HAS_BUILTIN_FLASH

--- a/ports/nrf/drivers/flash.h
+++ b/ports/nrf/drivers/flash.h
@@ -1,0 +1,64 @@
+/*
+ * This file is part of the Micro Python project, http://micropython.org/
+ *
+ * The MIT License (MIT)
+ *
+ * Copyright (c) 2018 Ayke van Laethem
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+
+#ifndef __MICROPY_INCLUDED_LIB_FLASH_H__
+#define __MICROPY_INCLUDED_LIB_FLASH_H__
+
+#include "nrf_nvmc.h"
+
+#if defined(NRF51)
+#define FLASH_PAGESIZE (1024)
+
+#elif defined(NRF52)
+#define FLASH_PAGESIZE (4096)
+#else
+#error Unknown chip
+#endif
+
+#define FLASH_IS_PAGE_ALIGNED(addr) ((uint32_t)(addr) & (FLASH_PAGESIZE - 1))
+
+#if BLUETOOTH_SD
+
+typedef enum {
+    FLASH_STATE_BUSY,
+    FLASH_STATE_SUCCESS,
+    FLASH_STATE_ERROR,
+} flash_state_t;
+
+void flash_page_erase(uint32_t address);
+void flash_write_byte(uint32_t address, uint8_t value);
+void flash_write_bytes(uint32_t address, const uint8_t *src, uint32_t num_bytes);
+void flash_operation_finished(flash_state_t result);
+
+#else
+
+#define flash_page_erase nrf_nvmc_page_erase
+#define flash_write_byte nrf_nvmc_write_byte
+#define flash_write_bytes nrf_nvmc_write_bytes
+
+#endif
+
+#endif // __MICROPY_INCLUDED_LIB_FLASH_H__

--- a/ports/nrf/modules/uos/microbitfs.c
+++ b/ports/nrf/modules/uos/microbitfs.c
@@ -31,7 +31,7 @@
 #include <sys/stat.h>
 
 #include "microbitfs.h"
-#include "nrf_nvmc.h"
+#include "drivers/flash.h"
 #include "modrandom.h"
 #include "py/nlr.h"
 #include "py/obj.h"
@@ -48,17 +48,6 @@
 #else
 #define DEBUG(s) (void)0
 #endif
-
-#if defined(NRF51)
-#define HAL_NVMC_PAGESIZE (1024)
-
-#elif defined(NRF52)
-#define HAL_NVMC_PAGESIZE (4096)
-#else
-#error Unknown chip
-#endif
-
-#define HAL_NVMC_IS_PAGE_ALIGNED(addr) ((uint32_t)(addr) & (HAL_NVMC_PAGESIZE - 1))
 
 /**  How it works:
  * The File System consists of up to MAX_CHUNKS_IN_FILE_SYSTEM chunks of CHUNK_SIZE each,
@@ -96,7 +85,7 @@
 
 //Minimum number of free chunks to justify sweeping.
 //If this is too low it may cause excessive wear
-#define MIN_CHUNKS_FOR_SWEEP (HAL_NVMC_PAGESIZE / CHUNK_SIZE)
+#define MIN_CHUNKS_FOR_SWEEP (FLASH_PAGESIZE / CHUNK_SIZE)
 
 #define FILE_NOT_FOUND ((uint8_t)-1)
 
@@ -165,25 +154,25 @@ STATIC inline byte *roundup(byte *addr, uint32_t align) {
 
 
 STATIC inline void *first_page(void) {
-    return _flash_user_end - HAL_NVMC_PAGESIZE * first_page_index;
+    return _flash_user_end - FLASH_PAGESIZE * first_page_index;
 }
 
 STATIC inline void *last_page(void) {
-    return _flash_user_end - HAL_NVMC_PAGESIZE * last_page_index;
+    return _flash_user_end - FLASH_PAGESIZE * last_page_index;
 }
 
 STATIC void init_limits(void) {
     // First determine where to end
     byte *end = _flash_user_end;
-    end = rounddown(end, HAL_NVMC_PAGESIZE)-HAL_NVMC_PAGESIZE;
-    last_page_index = (_flash_user_end - end)/HAL_NVMC_PAGESIZE;
+    end = rounddown(end, FLASH_PAGESIZE)-FLASH_PAGESIZE;
+    last_page_index = (_flash_user_end - end)/FLASH_PAGESIZE;
 
     // Now find the start
-    byte *start = roundup(end - CHUNK_SIZE*MAX_CHUNKS_IN_FILE_SYSTEM, HAL_NVMC_PAGESIZE);
+    byte *start = roundup(end - CHUNK_SIZE*MAX_CHUNKS_IN_FILE_SYSTEM, FLASH_PAGESIZE);
     while (start < _flash_user_start) {
-        start += HAL_NVMC_PAGESIZE;
+        start += FLASH_PAGESIZE;
     }
-    first_page_index = (_flash_user_end - start)/HAL_NVMC_PAGESIZE;
+    first_page_index = (_flash_user_end - start)/FLASH_PAGESIZE;
     chunks_in_file_system = (end-start)>>MBFS_LOG_CHUNK_SIZE;
 }
 
@@ -196,24 +185,24 @@ void microbit_filesystem_init(void) {
     randomise_start_index();
     file_chunk *base = first_page();
     if (base->marker == PERSISTENT_DATA_MARKER) {
-        file_system_chunks = &base[(HAL_NVMC_PAGESIZE>>MBFS_LOG_CHUNK_SIZE)-1];
+        file_system_chunks = &base[(FLASH_PAGESIZE>>MBFS_LOG_CHUNK_SIZE)-1];
     } else if (((file_chunk *)last_page())->marker == PERSISTENT_DATA_MARKER) {
         file_system_chunks = &base[-1];
     } else {
-        nrf_nvmc_write_byte((uint32_t)&((file_chunk *)last_page())->marker, PERSISTENT_DATA_MARKER);
+        flash_write_byte((uint32_t)&((file_chunk *)last_page())->marker, PERSISTENT_DATA_MARKER);
         file_system_chunks = &base[-1];
     }
 }
 
 STATIC void copy_page(void *dest, void *src) {
     DEBUG(("FILE DEBUG: Copying page from %lx to %lx.\r\n", (uint32_t)src, (uint32_t)dest));
-    nrf_nvmc_page_erase((uint32_t)dest);
+    flash_page_erase((uint32_t)dest);
     file_chunk *src_chunk = src;
     file_chunk *dest_chunk = dest;
-    uint32_t chunks = HAL_NVMC_PAGESIZE>>MBFS_LOG_CHUNK_SIZE;
+    uint32_t chunks = FLASH_PAGESIZE>>MBFS_LOG_CHUNK_SIZE;
     for (uint32_t i = 0; i < chunks; i++) {
         if (src_chunk[i].marker != FREED_CHUNK) {
-            nrf_nvmc_write_bytes((uint32_t)&dest_chunk[i], (uint8_t*)&src_chunk[i], CHUNK_SIZE);
+            flash_write_bytes((uint32_t)&dest_chunk[i], (uint8_t*)&src_chunk[i], CHUNK_SIZE);
         }
     }
 }
@@ -233,7 +222,7 @@ STATIC void filesystem_sweep(void) {
     uint8_t *page;
     uint8_t *end_page;
     int step;
-    uint32_t page_size = HAL_NVMC_PAGESIZE;
+    uint32_t page_size = FLASH_PAGESIZE;
     DEBUG(("FILE DEBUG: Sweeping file system\r\n"));
     if (((file_chunk *)first_page())->marker == PERSISTENT_DATA_MARKER) {
         config = *(persistent_config_t *)first_page();
@@ -248,12 +237,12 @@ STATIC void filesystem_sweep(void) {
     }
     while (page != end_page) {
         uint8_t *next_page = page+step;
-        nrf_nvmc_page_erase((uint32_t)page);
+        flash_page_erase((uint32_t)page);
         copy_page(page, next_page);
         page = next_page;
     }
-    nrf_nvmc_page_erase((uint32_t)end_page);
-    nrf_nvmc_write_bytes((uint32_t)end_page, (uint8_t*)&config, sizeof(config));
+    flash_page_erase((uint32_t)end_page);
+    flash_write_bytes((uint32_t)end_page, (uint8_t*)&config, sizeof(config));
     microbit_filesystem_init();
 }
 
@@ -303,13 +292,13 @@ STATIC uint8_t find_chunk_and_erase(void) {
     // Search for FREED page, and total up FREED chunks
     uint32_t freed_chunks = 0;
     index = start_index;
-    uint32_t chunks_per_page = HAL_NVMC_PAGESIZE>>MBFS_LOG_CHUNK_SIZE;
+    uint32_t chunks_per_page = FLASH_PAGESIZE>>MBFS_LOG_CHUNK_SIZE;
     do {
         const file_chunk *p = &file_system_chunks[index];
         if (p->marker == FREED_CHUNK) {
             freed_chunks++;
         }
-        if (HAL_NVMC_IS_PAGE_ALIGNED(p)) {
+        if (FLASH_IS_PAGE_ALIGNED(p)) {
             uint32_t i;
             for (i = 0; i < chunks_per_page; i++) {
                 if (p[i].marker != FREED_CHUNK)
@@ -317,7 +306,7 @@ STATIC uint8_t find_chunk_and_erase(void) {
             }
             if (i == chunks_per_page) {
                 DEBUG(("FILE DEBUG: Found freed page of chunks: %d\r\n", index));
-                nrf_nvmc_page_erase((uint32_t)&file_system_chunks[index]);
+                flash_page_erase((uint32_t)&file_system_chunks[index]);
                 return index;
             }
         }
@@ -342,7 +331,7 @@ STATIC file_descriptor_obj *microbit_file_descriptor_new(uint8_t start_chunk, bo
 
 STATIC void clear_file(uint8_t chunk) {
     do {
-        nrf_nvmc_write_byte((uint32_t)&(file_system_chunks[chunk].marker), FREED_CHUNK);
+        flash_write_byte((uint32_t)&(file_system_chunks[chunk].marker), FREED_CHUNK);
         DEBUG(("FILE DEBUG: Freeing chunk %d.\n", chunk));
         chunk = file_system_chunks[chunk].next_chunk;
     } while (chunk <= chunks_in_file_system);
@@ -362,9 +351,9 @@ STATIC file_descriptor_obj *microbit_file_open(const char *name, size_t name_len
         if (index == FILE_NOT_FOUND) {
             mp_raise_OSError(MP_ENOSPC);
         }
-        nrf_nvmc_write_byte((uint32_t)&(file_system_chunks[index].marker), FILE_START);
-        nrf_nvmc_write_byte((uint32_t)&(file_system_chunks[index].header.name_len), name_len);
-        nrf_nvmc_write_bytes((uint32_t)&(file_system_chunks[index].header.filename[0]), (uint8_t*)name, name_len);
+        flash_write_byte((uint32_t)&(file_system_chunks[index].marker), FILE_START);
+        flash_write_byte((uint32_t)&(file_system_chunks[index].header.name_len), name_len);
+        flash_write_bytes((uint32_t)&(file_system_chunks[index].header.filename[0]), (uint8_t*)name, name_len);
     } else {
         if (index == FILE_NOT_FOUND) {
             return NULL;
@@ -419,8 +408,8 @@ STATIC int advance(file_descriptor_obj *self, uint32_t n, bool write) {
                 return ENOSPC;
             }
             // Link next chunk to this one
-            nrf_nvmc_write_byte((uint32_t)&(file_system_chunks[self->seek_chunk].next_chunk), next_chunk);
-            nrf_nvmc_write_byte((uint32_t)&(file_system_chunks[next_chunk].marker), self->seek_chunk);
+            flash_write_byte((uint32_t)&(file_system_chunks[self->seek_chunk].next_chunk), next_chunk);
+            flash_write_byte((uint32_t)&(file_system_chunks[next_chunk].marker), self->seek_chunk);
         }
         self->seek_chunk = file_system_chunks[self->seek_chunk].next_chunk;
     }
@@ -469,7 +458,7 @@ STATIC mp_uint_t microbit_file_write(mp_obj_t obj, const void *buf, mp_uint_t si
     const uint8_t *data = buf;
     while (len) {
         uint32_t to_write = MIN(((uint32_t)(DATA_PER_CHUNK - self->seek_offset)), len);
-        nrf_nvmc_write_bytes((uint32_t)seek_address(self), data, to_write);
+        flash_write_bytes((uint32_t)seek_address(self), data, to_write);
         int err = advance(self, to_write, true);
         if (err) {
             *errcode = err;
@@ -483,7 +472,7 @@ STATIC mp_uint_t microbit_file_write(mp_obj_t obj, const void *buf, mp_uint_t si
 
 STATIC void microbit_file_close(file_descriptor_obj *fd) {
     if (fd->writable) {
-        nrf_nvmc_write_byte((uint32_t)&(file_system_chunks[fd->start_chunk].header.end_offset), fd->seek_offset);
+        flash_write_byte((uint32_t)&(file_system_chunks[fd->start_chunk].header.end_offset), fd->seek_offset);
     }
     fd->open = false;
 }


### PR DESCRIPTION
Quickly tested on an nrf51, it appears to work without SD, with disabled SD and with enabled SD.