### PR TITLE
nrf/drivers/bluetooth: Remove legacy HAL driver includes.

### DIFF
--- a/ports/nrf/drivers/bluetooth/ble_drv.c
+++ b/ports/nrf/drivers/bluetooth/ble_drv.c
@@ -36,7 +36,6 @@
 #include "nrf_sdm.h"
 #include "ble_gap.h"
 #include "ble.h" // sd_ble_uuid_encode
-#include "hal_irq.h"
 #include "drivers/flash.h"
 #include "mphalport.h"
 

--- a/ports/nrf/drivers/bluetooth/ble_uart.c
+++ b/ports/nrf/drivers/bluetooth/ble_uart.c
@@ -29,14 +29,10 @@
 #include <string.h>
 #include "ble_uart.h"
 #include "ringbuffer.h"
-#include "hal/hal_time.h"
+#include "mphalport.h"
 #include "lib/utils/interrupt_char.h"
 
 #if MICROPY_PY_BLE_NUS
-
-#if BLUETOOTH_WEBBLUETOOTH_REPL
-#include "hal_time.h"
-#endif // BLUETOOTH_WEBBLUETOOTH_REPL
 
 static ubluepy_uuid_obj_t uuid_obj_service = {
     .base.type = &ubluepy_uuid_type,


### PR DESCRIPTION
These were not used anymore so can be removed.

Might conflict with #19.